### PR TITLE
Add support for videos with private links

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ Another option is to use the [no-ssr](https://nuxtjs.org/api/components-no-ssr/)
         <td>Yes</td>
     </tr>
     <tr>
+        <td>video-url</td>
+        <td>String</td>
+        <td>undefined</td>
+        <td>Vimeo url to play video (if using private links)</td>
+        <td>No</td>
+    </tr>
+    <tr>
         <td>loop</td>
         <td>Boolean</td>
         <td>false</td>

--- a/src/main.js
+++ b/src/main.js
@@ -38,6 +38,9 @@ export default {
     videoId: {
       required: true
     },
+    videoUrl: {
+      default: undefined
+    },
     loop: {
       default: false
     },
@@ -103,6 +106,7 @@ export default {
       loop: this.loop,
       autoplay: this.autoplay
     }
+    if (this.videoUrl) { options.url = this.videoUrl }
 
     this.player = new Player(this.elementId, assign(options, this.options))
 


### PR DESCRIPTION
If you supply the vimeo player with a url in the [embed options](https://github.com/vimeo/player.js/#embed-options) object, videos with private links will work.

This PR adds a vimeoUrl prop to the component. If supplied with a playable url, the vimeo player will use it instead.