### PR TITLE
[ENHANCEMENT] Adding controls prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ Another option is to use the [no-ssr](https://nuxtjs.org/api/components-no-ssr/)
         <td>Upon reaching the end of the video, automatically seek back to the start.</td>
         <td>No</td>
     </tr>
+    <tr>
+        <td>controls</td>
+        <td>Boolean</td>
+        <td>true</td>
+        <td>This parameter if `false` will hide all elements in the player (play bar, sharing buttons, etc) for a chromeless experience. ⚠️Warning: When using this parameter, the play bar and UI will be hidden. To start playback for your viewers, you'll need to either enable autoplay or use our player SDK to start and control playback. **(available to Plus, PRO, or Business members)**</td>
+        <td>No</td>
+    </tr>
 </table>
  
 ## Methods

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "standard-version": "^4.2.0"
   },
   "dependencies": {
-    "@vimeo/player": "^2.6.3",
+    "@vimeo/player": "^2.10.0",
     "object-assign": "^4.1.1"
   },
   "peerDependencies": {

--- a/src/main.js
+++ b/src/main.js
@@ -46,6 +46,9 @@ export default {
     },
     autoplay: {
       default: false
+    },
+    controls: {
+      default: true
     }
   },
   render (h) {
@@ -104,7 +107,8 @@ export default {
       width: this.playerWidth,
       height: this.playerHeight,
       loop: this.loop,
-      autoplay: this.autoplay
+      autoplay: this.autoplay,
+      controls: this.controls
     }
     if (this.videoUrl) { options.url = this.videoUrl }
 


### PR DESCRIPTION
This PR adds `controls` prop to the player, to allow hidding the controls of the native vimeo player, as long your account is PRO/Business/etc. 

I have also updated README.md to include this information.

(sorry for the mess, git is hard sometimes)